### PR TITLE
Updated Github actions to build for both AMD64 and ARM64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,12 +36,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: Main workflow
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 env:
   REGISTRY: ghcr.io
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -37,6 +43,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,8 @@ name: Main workflow
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18
 
-ENV RUNTIME_ENV container
+ENV RUNTIME_ENV=container
 
 RUN useradd -u 3000 recv
 


### PR DESCRIPTION
### Description

I've been meaning to start playing around this for quite a while now, unfortunately the machine that I planned on running this one uses Docker but is powered by an ARM64 CPU. But unfortunately, the currently available Docker image doesn't run on ARM64 because it's build for AMD64.

This PR introduces the functionality to build the docker images for both CPU architectures. Next to that I had to slightly bump up the version for the Github steps. Also I took the opportunity to clean up a deprecation warning where the ENV variable needs to be set in a slighty different form. More information on this can be found here: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/

If you want to see the Github pipeline in action, you can find one of the successful build logs here: https://github.com/sandervankasteel/arona/actions/runs/10426242416